### PR TITLE
feat: add date header if not present

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -35,6 +35,12 @@ func (h *handler) ForwardRequest(c *gin.Context) {
 	req.Host = h.proxy.TargetHost
 	req.Header.Set("Host", h.proxy.TargetHost)
 
+	// Add Date header since some clients don't automatically add it
+	date := req.Header.Get("Date")
+	if date == "" {
+		req.Header.Set("Date", time.Now().Format(http.TimeFormat))
+	}
+
 	start := time.Now()
 	signedReq, err := h.reqSigner.SignRequest(req)
 	singingDuration := time.Since(start)


### PR DESCRIPTION
Add `Date` header to the proxied request if the client doesn't provide it.
The header will be in this format `Date: <day-name>, <day> <month> <year> <hour>:<minute>:<second> GMT`, as in `http.TimeFormat`.