### PR TITLE
feat: add config option to set Access-Control-Allow-Origin header on responses

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,8 +7,9 @@ type Config struct {
 }
 
 type ServerConfig struct {
-	Port int       `mapstructure:"port"`
-	SSL  SSLConfig `mapstructure:"ssl"`
+	Port                     int       `mapstructure:"port"`
+	SSL                      SSLConfig `mapstructure:"ssl"`
+	AccessControlAllowOrigin string    `mapstructure:"accessControlAllowOrigin"`
 }
 
 type ProxyConfig struct {

--- a/config/config_test.yaml
+++ b/config/config_test.yaml
@@ -4,6 +4,7 @@ server:
     enable: false
     certFilePath: "/etc/ssl/certs/cert.crt"
     keyFilePath: "/etc/ssl/private/private.key"
+  accessControlAllowOrigin: "*"
 
 proxy:
   upstreamTarget: "https://api.form3.tech/v1"

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -129,6 +129,7 @@ func TestLoadConfig(t *testing.T) {
 				CertFilePath: "/etc/ssl/certs/cert.crt",
 				KeyFilePath:  "/etc/ssl/private/private.key",
 			},
+			AccessControlAllowOrigin: "*",
 		},
 		Log: LogConfig{
 			Level:  "debug",

--- a/example/config_example.yaml
+++ b/example/config_example.yaml
@@ -11,6 +11,8 @@ server:
     certFilePath: "/etc/ssl/certs/cert.crt"
     # Location of the proxy's private key, if SSL is enabled
     keyFilePath: "/etc/ssl/private/private.key"
+  # Value to be used in the Access-Control-Allow-Origin response header
+  accessControlAllowOrigin: "*"
 
 # Request forward proxy config
 proxy:

--- a/proxy/middleware.go
+++ b/proxy/middleware.go
@@ -13,6 +13,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	AccessControlAllowOriginHeader string = "Access-Control-Allow-Origin"
+)
+
 func RecoverMiddleware(metricPublisher MetricPublisher) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		defer func() {
@@ -70,4 +74,13 @@ func LogAndMetricsMiddleware(metricPublisher MetricPublisher) gin.HandlerFunc {
 			"client_ip":   c.ClientIP(),
 		}).Info("request summary")
 	}
+}
+
+func CORSMiddleware(accessControlAllowOrigin string) gin.HandlerFunc {
+	if accessControlAllowOrigin != "" {
+		return func(c *gin.Context) {
+			c.Writer.Header().Set(AccessControlAllowOriginHeader, accessControlAllowOrigin)
+		}
+	}
+	return func(_ *gin.Context) {}
 }

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -33,6 +33,7 @@ func NewServer(cfg config.ServerConfig, handler Handler, metric MetricPublisher)
 	router.NoRoute(
 		RecoverMiddleware(metric),
 		LogAndMetricsMiddleware(metric),
+		CORSMiddleware(cfg.AccessControlAllowOrigin),
 		handler.ForwardRequest,
 	)
 


### PR DESCRIPTION
This will stop CORS errors when the calling service is on a different host.